### PR TITLE
Support semicolon-delimited CSV uploads

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -325,11 +325,13 @@
 
         function parseCSV(text) {
             const lines = text.split(/\r?\n/).filter(line => line.trim() !== '');
-            const header = lines[0].split(',').map(h => h.trim());
+            // Soportar archivos CSV separados por punto y coma (Excel en español)
+            const delimiter = lines[0].includes(';') && !lines[0].includes(',') ? ';' : ',';
+            const header = lines[0].split(delimiter).map(h => h.trim());
             return lines.slice(1).map(line => {
-                const values = line.split(',');
+                const values = line.split(delimiter);
                 return header.reduce((obj, h, i) => {
-                    obj[h] = values[i].trim().replace(/"/g, '');
+                    obj[h] = values[i] ? values[i].trim().replace(/"/g, '') : '';
                     return obj;
                 }, {});
             });

--- a/functions/index.js
+++ b/functions/index.js
@@ -4,20 +4,24 @@ const admin = require("firebase-admin");
 admin.initializeApp();
 
 // --- CSV PARSER ---
-// A simple parser, not robust for complex CSVs (e.g., with commas in values)
+// Detects whether the CSV uses commas or semicolons as delimiters.
+// Still a simple parser, not robust for complex CSVs (e.g., with embedded commas).
 function parseCSV(text) {
     const lines = text.split(/\r?\n/).filter(line => line.trim() !== '');
     if (lines.length < 2) {
         throw new functions.https.HttpsError('invalid-argument', 'El CSV debe tener un encabezado y al menos una fila de datos.');
     }
-    const header = lines[0].split(',').map(h => h.trim());
+
+    // Determine delimiter: default comma, but switch to semicolon if no commas are present
+    const delimiter = lines[0].includes(';') && !lines[0].includes(',') ? ';' : ',';
+    const header = lines[0].split(delimiter).map(h => h.trim());
     const requiredHeaders = ['escuela_id', 'dni'];
     if (!requiredHeaders.every(h => header.includes(h))) {
         throw new functions.https.HttpsError('invalid-argument', `El encabezado del CSV debe contener las columnas: ${requiredHeaders.join(', ')}.`);
     }
 
     return lines.slice(1).map(line => {
-        const values = line.split(',');
+        const values = line.split(delimiter);
         return header.reduce((obj, h, i) => {
             obj[h] = values[i] ? values[i].trim().replace(/"/g, '') : '';
             return obj;


### PR DESCRIPTION
## Summary
- Allow parsing CSV files separated by semicolons on the admin dashboard
- Handle semicolon-delimited CSV in Cloud Function for fiscales

## Testing
- `node --check functions/index.js`
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b77740785c8326b150aca34bcbc4f4