### PR TITLE
Support semicolon-delimited CSV uploads

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -68,7 +68,7 @@
                 <div class="border border-gray-200 p-4 rounded-lg flex flex-col">
                     <h3 class="font-semibold text-lg mb-2">1. Cargar Listas</h3>
                     <p class="text-xs text-gray-500 mb-2">CSV con columnas: `id`, `nombre_lista`.</p>
-                     <a href='data:text/csv;charset=utf-8,id,nombre_lista%0Alista_01,CONSTRUYENDO PORVENIR%0Alista_02,ACCION VECINAL' download="listas_ejemplo_consolidadas.csv" class="text-sm text-indigo-600 hover:text-indigo-800 font-medium mb-4">Descargar CSV de ejemplo</a>
+                     <a href='data:text/csv;charset=utf-8,id;nombre_lista%0Alista_01;CONSTRUYENDO PORVENIR%0Alista_02;ACCION VECINAL' download="listas_ejemplo_consolidadas.csv" class="text-sm text-indigo-600 hover:text-indigo-800 font-medium mb-4">Descargar CSV de ejemplo</a>
                     <form class="space-y-3 mt-auto" data-upload-type="listas">
                         <input type="file" class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100" accept=".csv" required>
                         <button type="submit" class="w-full bg-indigo-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-indigo-700">Cargar Listas</button>
@@ -78,7 +78,7 @@
                 <div class="border border-gray-200 p-4 rounded-lg flex flex-col">
                     <h3 class="font-semibold text-lg mb-2">2. Cargar Escuelas</h3>
                     <p class="text-xs text-gray-500 mb-2">CSV con: `id`, `nombre`, `lat`, `lng`, `mesas` (separadas por coma: "1001,1002").</p>
-                    <a href='data:text/csv;charset=utf-8,id,nombre,lat,lng,mesas%0A1,Escuela San Martín,-34.468,-58.515,"1001,1002"%0A15,"E.P. N°1 Sarmiento",-34.47,-58.52,"7001,7002"' download="escuelas_ejemplo.csv" class="text-sm text-indigo-600 hover:text-indigo-800 font-medium mb-4">Descargar CSV de ejemplo</a>
+                    <a href='data:text/csv;charset=utf-8,id;nombre;lat;lng;mesas%0A1;Escuela San Martín;-34.468;-58.515;"1001,1002"%0A15;"E.P. N°1 Sarmiento";-34.47;-58.52;"7001,7002"' download="escuelas_ejemplo.csv" class="text-sm text-indigo-600 hover:text-indigo-800 font-medium mb-4">Descargar CSV de ejemplo</a>
                     <form class="space-y-3 mt-auto" data-upload-type="escuelas">
                         <input type="file" class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100" accept=".csv" required>
                         <button type="submit" class="w-full bg-indigo-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-indigo-700">Cargar Escuelas</button>
@@ -88,7 +88,7 @@
                 <div class="border border-gray-200 p-4 rounded-lg flex flex-col">
                     <h3 class="font-semibold text-lg mb-2">3. Cargar Fiscales</h3>
                     <p class="text-xs text-gray-500 mb-2">CSV con: `escuela_id`, `dni`. Se creará un usuario `escuela{id}@fiscal.app` con el DNI como contraseña.</p>
-                    <a href='data:text/csv;charset=utf-8,escuela_id,dni%0A15,12345678%0A22,87654321' download="fiscales_ejemplo.csv" class="text-sm text-indigo-600 hover:text-indigo-800 font-medium mb-4">Descargar CSV de ejemplo</a>
+                    <a href='data:text/csv;charset=utf-8,escuela_id;dni%0A15;12345678%0A22;87654321' download="fiscales_ejemplo.csv" class="text-sm text-indigo-600 hover:text-indigo-800 font-medium mb-4">Descargar CSV de ejemplo</a>
                     <form class="space-y-3 mt-auto" data-upload-type="fiscales">
                         <input type="file" class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100" accept=".csv" required>
                         <button type="submit" class="w-full bg-indigo-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-indigo-700">Cargar Fiscales</button>
@@ -325,11 +325,13 @@
 
         function parseCSV(text) {
             const lines = text.split(/\r?\n/).filter(line => line.trim() !== '');
-            const header = lines[0].split(',').map(h => h.trim());
+            // Soportar archivos CSV separados por punto y coma (Excel en español)
+            const delimiter = lines[0].includes(';') && !lines[0].includes(',') ? ';' : ',';
+            const header = lines[0].split(delimiter).map(h => h.trim());
             return lines.slice(1).map(line => {
-                const values = line.split(',');
+                const values = line.split(delimiter);
                 return header.reduce((obj, h, i) => {
-                    obj[h] = values[i].trim().replace(/"/g, '');
+                    obj[h] = values[i] ? values[i].trim().replace(/"/g, '') : '';
                     return obj;
                 }, {});
             });

--- a/functions/index.js
+++ b/functions/index.js
@@ -4,20 +4,24 @@ const admin = require("firebase-admin");
 admin.initializeApp();
 
 // --- CSV PARSER ---
-// A simple parser, not robust for complex CSVs (e.g., with commas in values)
+// Detects whether the CSV uses commas or semicolons as delimiters.
+// Still a simple parser, not robust for complex CSVs (e.g., with embedded commas).
 function parseCSV(text) {
     const lines = text.split(/\r?\n/).filter(line => line.trim() !== '');
     if (lines.length < 2) {
         throw new functions.https.HttpsError('invalid-argument', 'El CSV debe tener un encabezado y al menos una fila de datos.');
     }
-    const header = lines[0].split(',').map(h => h.trim());
+
+    // Determine delimiter: default comma, but switch to semicolon if no commas are present
+    const delimiter = lines[0].includes(';') && !lines[0].includes(',') ? ';' : ',';
+    const header = lines[0].split(delimiter).map(h => h.trim());
     const requiredHeaders = ['escuela_id', 'dni'];
     if (!requiredHeaders.every(h => header.includes(h))) {
         throw new functions.https.HttpsError('invalid-argument', `El encabezado del CSV debe contener las columnas: ${requiredHeaders.join(', ')}.`);
     }
 
     return lines.slice(1).map(line => {
-        const values = line.split(',');
+        const values = line.split(delimiter);
         return header.reduce((obj, h, i) => {
             obj[h] = values[i] ? values[i].trim().replace(/"/g, '') : '';
             return obj;


### PR DESCRIPTION
## Summary
- Allow parsing CSV files separated by semicolons on the admin dashboard
- Handle semicolon-delimited CSV in Cloud Function for fiscales
- Provide semicolon-separated example CSV downloads for listas, escuelas, and fiscales

## Testing
- `node --check functions/index.js`
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b77740785c8326b150aca34bcbc4f4